### PR TITLE
Weights mean_salt_rate by icewgt

### DIFF
--- a/src/module_MEDIATOR.F90
+++ b/src/module_MEDIATOR.F90
@@ -5534,6 +5534,16 @@ module module_MEDIATOR
 !      line=__LINE__, file=__FILE__)) return  ! bail out
 
     !-------------
+    ! field_for_ocn = field_from_ice * ice_fraction
+    !-------------
+
+    call fieldBundle_FieldMerge(is_local%wrap%FBforOcn, 'mean_salt_rate', &
+                                is_local%wrap%FBIce_o , 'mean_salt_rate', icewgt, &
+                                rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, file=__FILE__)) return  ! bail out
+
+    !-------------
     ! field_for_ocn = field_from_atm * (1-ice_fraction) + field_from_ice * (ice_fraction)
     !-------------
 


### PR DESCRIPTION
The mean_salt_rate sent from CICE5 is unweighted by ice concentration before being exported. It needs to be re-weighted by ice concentration before being exported to MOM6