### PR TITLE
Support the official NUOPC Verbosity strings

### DIFF
--- a/src/module_MEDIATOR.F90
+++ b/src/module_MEDIATOR.F90
@@ -922,7 +922,8 @@ module module_MEDIATOR
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, file=__FILE__)) return  ! bail out
     dbug_flag = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max"/), specialValueList=(/0,255/), rc=rc)
+      specialStringList=(/"off","low","high","max"/), &
+      specialValueList=(/0,1,100,255/), rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, file=__FILE__)) return  ! bail out
     write(msgString,'(A,i6)') trim(subname)//' dbug_flag = ',dbug_flag


### PR DESCRIPTION
To be compliant with NUOPC in ESMF 8.0 release, the official Verbosity strings "off", "low", "high", "max" need to be supported.

This change is expected to be fully transparent across NEMS applications. The benefit is that the Verbosity attribute on the Mediator can now be set to any of the official strings. Especially the "high" setting is useful in generating detailed but still readable output from the generic portions of NUOPC.