### PR TITLE
Add standard name to NUOPC Field Dictionary

### DIFF
--- a/src/module_EARTH_GRID_COMP.F90
+++ b/src/module_EARTH_GRID_COMP.F90
@@ -3018,6 +3018,18 @@
       endif
 
       if (.not.NUOPC_FieldDictionaryHasEntry( &
+        "inst_spec_humid_conv_tendency_levels")) then
+        call NUOPC_FieldDictionaryAddEntry( &
+          standardName="inst_spec_humid_conv_tendency_levels", &
+          canonicalUnits="kg kg-1 s-1", &
+          rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, &
+          file=__FILE__)) &
+          return  ! bail out
+      endif
+
+      if (.not.NUOPC_FieldDictionaryHasEntry( &
         "inst_friction_velocity")) then
         call NUOPC_FieldDictionaryAddEntry( &
           standardName="inst_friction_velocity", &


### PR DESCRIPTION
This PR adds the standard name `inst_spec_humid_conv_tendency_levels` to the NUOPC Field Dictionary in NEMS.

This standard name defines the _instantaneous specific humidity tendency due to convection_ field, exported by FV3GFS to the coupled chemistry model.