### PR TITLE
This commit #refs 67538 (merge gmtb/develop into NOAA-EMC/develop)

### DIFF
--- a/src/conf/module-setup.csh.inc
+++ b/src/conf/module-setup.csh.inc
@@ -8,7 +8,13 @@ if ( { test -d /lfs3 } ) then
             source /apps/lmod/lmod/init/$__ms_shell
     endif
     module purge
-else if ( { test -d /scratch3 } ) then
+else if ( { test -d /scratch1 -a ! -d /scratch } ) then
+    # We are on NOAA Hera
+    if ( ! { module help >& /dev/null } ) then
+        source /apps/lmod/lmod/init/$__ms_shell
+    endif
+    module purge
+else if ( { test -d /scratch3 -a -d /scratch } ) then
     # We are on NOAA Theia
     if ( ! { module help >& /dev/null } ) then
         source /apps/lmod/lmod/init/$__ms_shell

--- a/src/conf/module-setup.sh.inc
+++ b/src/conf/module-setup.sh.inc
@@ -22,7 +22,13 @@ if [[ -d /lfs3 ]] ; then
         source /apps/lmod/lmod/init/$__ms_shell
     fi
     module purge
-elif [[ -d /scratch3 ]] ; then
+elif [[ -d /scratch1 && ! -d /scratch ]] ; then
+    # We are on NOAA Hera
+    if ( ! eval module help > /dev/null 2>&1 ) ; then
+        source /apps/lmod/lmod/init/$__ms_shell
+    fi
+    module purge
+elif [[ -d /scratch3 && -d /scratch ]] ; then
     # We are on NOAA Theia
     if ( ! eval module help > /dev/null 2>&1 ) ; then
         source /apps/lmod/lmod/init/$__ms_shell

--- a/src/module_MEDIATOR.F90
+++ b/src/module_MEDIATOR.F90
@@ -922,7 +922,7 @@ module module_MEDIATOR
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, file=__FILE__)) return  ! bail out
     dbug_flag = ESMF_UtilString2Int(value, &
-      specialStringList=(/"off","low","high","max"/), &
+      specialStringList=(/character(4)::"off","low","high","max"/), &
       specialValueList=(/0,1,100,255/), rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, file=__FILE__)) return  ! bail out


### PR DESCRIPTION
This commit #refs 67538, squashed commit of the following:

commit abe9efba450215961cdfc4948f76668ed4833f31
Author: Dom Heinzeller <dom.heinzeller@noaa.gov>
Date:   Tue Sep 3 16:25:12 2019 -0600

    src/module_MEDIATOR.F90: fix invalid Fortran code for GNU compiler

commit 89ddf135b08e7f7b77d72b4459fe40aa9cc3d361
Author: Dom Heinzeller <dom.heinzeller@noaa.gov>
Date:   Wed Aug 28 13:36:52 2019 -0600

    src/incmake/env/rdhpcs/detect.mk: bugfix for NEMSCompsetRun

commit 283eeb11bbde78c8e2d761e6e42b6af074655732
Merge: 1c71222c e142f4ef
Author: Dom Heinzeller <dom.heinzeller@icloud.com>
Date:   Tue Aug 27 15:45:57 2019 -0600

    Merge pull request #2 from climbfuji/hera_update_20190827

    gmtb/develop: update hera config

commit e142f4ef8cf9ed3104425a1c4f92ff6a14436c43
Author: Dom Heinzeller <dom.heinzeller@noaa.gov>
Date:   Tue Aug 27 15:04:16 2019 -0600

    src/incmake/env/rdhpcs/detect.mk: test for hostname prefix, since hera and theia both have /scratch1 through /scratch4 mounted

commit 028e1e8c662c52ef999831b0129c7663b7216a19
Author: Dom Heinzeller <dom.heinzeller@noaa.gov>
Date:   Tue Aug 27 13:45:29 2019 -0600

    Update src/incmake/env/rdhpcs/detect.mk, src/conf/module-setup.csh.inc, src/conf/module-setup.sh.inc after move from Juno test system to Hera. Since /scratch4 from theia is also mounted on hera, need to switch the order of detection.

commit 1c71222cb07c9d6c006cc305050afe193adf5ce4
Merge: 6bf81091 5b244abe
Author: Dom Heinzeller <dom.heinzeller@icloud.com>
Date:   Sat Aug 17 16:25:57 2019 -0600

    Merge pull request #1 from climbfuji/hera_support

    Add support for hera/juno (theia successor)

commit 5b244abe31b637c5f5521dddab454a44d49e4f3f
Author: Dom Heinzeller <dom.heinzeller@noaa.gov>
Date:   Fri Aug 16 09:33:34 2019 -0600

    Add support for hera/juno (theia successor)
