### PR TITLE
Fixing a runtime error for GNU compiler on Cheyenne

### DIFF
--- a/src/module_MEDIATOR.F90
+++ b/src/module_MEDIATOR.F90
@@ -922,7 +922,7 @@ module module_MEDIATOR
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, file=__FILE__)) return  ! bail out
     dbug_flag = ESMF_UtilString2Int(value, &
-      specialStringList=(/character(4)::"off","low","high","max"/), &
+      specialStringList=(/"off ","low ","high","max "/), &
       specialValueList=(/0,1,100,255/), rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, file=__FILE__)) return  ! bail out


### PR DESCRIPTION
This PR fixes an issue with a code change introduced in https://github.com/NOAA-EMC/NEMS/pull/7 (src/module_MEDIATOR.F90).

While the original code changes in https://github.com/NOAA-EMC/NEMS/pull/7
are valid and standard Fortran and work on macOS with gcc-8.3.0 and gcc-9.1.0, they lead to a model crash on Cheyenne with gcc-8.3.0:
```
terminate called after throwing an instance of 'std::length_error'   what():  basic_string::_M_create
```
The solution is to revert to the failsafe version that we have used successfully in the past for both Intel and GNU.

I tested those changes to work for both Intel and GNU on Cheyenne and I would advocate for merging them as soon as we can (possibly before kicking off the final round of tests for https://vlab.ncep.noaa.gov/code-review/#/c/19568).