### PR TITLE
Update for NEMSCompsetRun on jet, bugfix for calling ccpp_prebuild.py in distclean phase

### DIFF
--- a/src/incmake/component_CCPP.mk
+++ b/src/incmake/component_CCPP.mk
@@ -61,12 +61,13 @@ $(ccpp_mk): configure
 
 # Rule for cleaning intermediate files
 distclean_CCPP: clean_CCPP
-	set -x                                                          ; \
+	set -xue                                                        ; \
+	export PATH_CCPP="$(CCPP_SRCDIR)"                               ; \
 	cd $(ROOTDIR)                                                   ; \
-	./ccpp/framework/scripts/ccpp_prebuild.py $(CCPP_CONFOPT) --clean ; \
-	cd "$(CCPP_SRCDIR)"                                             ; \
-	rm -rf "$(CCPP_SRCDIR)/lib"                                     ; \
-	rm -rf "$(CCPP_SRCDIR)/include"                                 ; \
+	$$PATH_CCPP/framework/scripts/ccpp_prebuild.py $(CCPP_CONFOPT) --clean ; \
+	cd $$PATH_CCPP                                                  ; \
+	rm -rf "$(CCPP_BINDIR)/lib"                                     ; \
+	rm -rf "$(CCPP_BINDIR)/include"                                 ; \
 	rm -f $(ccpp_mk)
 
 clean_CCPP:

--- a/tests/rtgen
+++ b/tests/rtgen
@@ -929,12 +929,9 @@ class RTGen(TestGen):
             out.write('module load emc-utils/1.0.0 ; export have_qoutql=YES\n')
         elif 'jet' in here.name:
             out.write('module load hpss\n')
-            out.write('module use /lfs3/projects/hwrf-vd/soft/modulefiles\n')
-            out.write('module load rocoto/1.3.0rc2\n')
+            out.write('module load rocoto/1.3.1\n')
             out.write('module use /misc/contrib/emc-utils/modulefiles\n')
             out.write('module load emc-utils/1.1.0\n')
-            #if produtil.fileop.find_exe('sbatch',raise_missing=False):
-            #    out.write('module load slurm\n')
             out.write('have_qoutql=YES\n')
         elif here.name == 'hera':
             out.write('module use /scratch1/NCEPDEV/nems/emc.nemspara/soft/modulefiles/\n')


### PR DESCRIPTION
**WORK IN PROGRESS, DO NOT MERGE YET**

Associated PRs:

https://github.com/NCAR/ccpp-framework/pull/230
https://github.com/NCAR/ccpp-physics/pull/340
https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere/pull/5
https://github.com/NOAA-EMC/fv3atm/pull/1
https://github.com/ufs-community/ufs-weather-model/pull/1
https://github.com/NOAA-EMC/NEMS/pull/11 (merged)
https://github.com/NOAA-EMC/NEMS/pull/12

See https://github.com/ufs-community/ufs-weather-model/pull/1 for a description and regression testing information.

Update for NEMS:
- tests/rtgen: update to run NEMSCompsetRun on jet (xjet)
- src/incmake/component_CCPP.mk: bugfix, correct path for calling ccpp_prebuild.py in distclean phase