### PR TITLE
Code changes to support DEBUG compilation based on appBuilder file

### DIFF
--- a/src/incmake/component_CICE.mk
+++ b/src/incmake/component_CICE.mk
@@ -31,7 +31,7 @@ CICE_ALL_OPTS=\
 $(cice_mk): configure
 	$(MODULE_LOGIC)                                                   ; \
 	set -eu                                                           ; \
-	export $(CICE_ALL_OPTS)                                           ; \
+	export $(CICE_ALL_OPTS) $(CICE_MAKEOPT)                           ; \
 	cd $(CICE_SRCDIR)                                                 ; \
 	./comp_ice.backend
 	+$(MODULE_LOGIC) ; cd $(CICE_CAPDIR) ; exec $(MAKE) -f makefile.nuopc    \

--- a/src/incmake/component_MOM6.mk
+++ b/src/incmake/component_MOM6.mk
@@ -23,7 +23,7 @@ MOM6_ALL_OPTS=\
 
 $(mom6_mk): $(fms_mk) configure
 	-rm -fr $(MOM6_SRCDIR)/exec
-	$(MODULE_LOGIC) ; export $(MOM6_ALL_OPTS)                     ; \
+	$(MODULE_LOGIC) ; export $(MOM6_ALL_OPTS) $(MOM6_MAKEOPT)     ; \
 	set -e                                                        ; \
 	cd $(MOM6_SRCDIR)                                             ; \
 	./compile.sh --platform $(FULL_MACHINE_ID) --fms-dir "$(FMS_BINDIR)"


### PR DESCRIPTION
1. component_MOM6.mk sets the MOM6_MAKEOPT environment variable for compile.sh
2. component_CICE.mk sets the CICE_MAKEOPT environment variable for comp_ice.backend

Resolves issue #22 