### PR TITLE
fixes problem with MPI_Comm_Split in openmpi when hash is negative

### DIFF
--- a/src/module_NEMS_Rusage.F90
+++ b/src/module_NEMS_Rusage.F90
@@ -687,7 +687,6 @@ contains
        endif
        hash=c_crc32c
      
-       if(hash < 0) hash = MPI_UNDEFINED
        call MPI_Comm_Split(commin,hash,rank_world,comm_name,error)
        if(error/=0) then
           ierr=2

--- a/src/module_NEMS_Rusage.F90
+++ b/src/module_NEMS_Rusage.F90
@@ -678,7 +678,7 @@ contains
        c_name1(1) = ctry(itry:itry)
        c_length=namelen+1
        c_error=-999
-       c_crc32c=nems_c_crc32(c_name1,c_length,c_error)
+       c_crc32c=abs(nems_c_crc32(c_name1,c_length,c_error))
        if(c_error/=0) then
           ! Should never get here.  This indicates the name is
           ! empty or beyond 2**31-3 bytes.
@@ -686,7 +686,8 @@ contains
           return
        endif
        hash=c_crc32c
-
+     
+       if(hash < 0) hash = MPI_UNDEFINED
        call MPI_Comm_Split(commin,hash,rank_world,comm_name,error)
        if(error/=0) then
           ierr=2


### PR DESCRIPTION
This fixes a problem when using openmpi. When the MPI_Comm_Split hash is negative, openmpi fails. This adds an abs() call to the hash that is created for the split.