### PR TITLE
Bugfix for issue "NEMS hash 044400a8eea19d1ce991a2adaa0b369ed0e067c7 and head of develop broken for GNU compilers"

### DIFF
--- a/src/module_EARTH_GRID_COMP.F90
+++ b/src/module_EARTH_GRID_COMP.F90
@@ -2622,7 +2622,7 @@
           return  ! bail out
       endif
       call NUOPC_FieldDictionarySetSyno( &
-        standardNames = (/"ice_fraction",&
+        standardNames = (/"ice_fraction         ",&
                           "sea_ice_concentration"/), rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__, &


### PR DESCRIPTION
src/module_EARTH_GRID_COMP.F90: bugfix for GNU compiler, lengths of strings have to match

see https://github.com/NOAA-EMC/NEMS/issues/41

This compiles with gcc/gfortran on macOS.

Note: this PR was created on top of hash 044400a8eea19d1ce991a2adaa0b369ed0e067c7, which is used by the ufs-weather-model; the head of develop seem to have advanced beyond this.