### PR TITLE
Port 2 hera to develop

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,6 @@
 [submodule "tests/produtil/NCEPLIBS-pyprodutil"]
 	path = tests/produtil/NCEPLIBS-pyprodutil
-	url = https://github.com/NOAA-EMC/NCEPLIBS-pyprodutil
-	branch = port-2-hera
+	#url = https://github.com/NOAA-EMC/NCEPLIBS-pyprodutil
+	#branch = port-2-hera
+	url = https://github.com/minsukji-NOAA/NCEPLIBS-pyprodutil
+	branch = merge_port-2-hera_to_develop

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,4 @@
 [submodule "tests/produtil/NCEPLIBS-pyprodutil"]
 	path = tests/produtil/NCEPLIBS-pyprodutil
-	#url = https://github.com/NOAA-EMC/NCEPLIBS-pyprodutil
-	#branch = port-2-hera
-	url = https://github.com/minsukji-NOAA/NCEPLIBS-pyprodutil
-	branch = merge_port-2-hera_to_develop
+	url = https://github.com/NOAA-EMC/NCEPLIBS-pyprodutil
+	branch = develop


### PR DESCRIPTION
This PR is related to #44 - point NEMS to the develop branch of NOAA-EMC/NCEPLIBS-pyprodutil (currently it points to the port-2-hera branch).

NCEPLIBS-pyprodutil's port-2-hera branch has been merged into the develop branch (https://github.com/NOAA-EMC/NCEPLIBS-pyprodutil/pull/4). Therefore, NEMS can now point to the NCEPLIBS-pryprodutil's develop branch.