### PR TITLE
use fluxes from bulk formula for open water without ice

### DIFF
--- a/src/module_MEDIATOR.F90
+++ b/src/module_MEDIATOR.F90
@@ -5483,10 +5483,10 @@ module module_MEDIATOR
       wgtm01(i,j)  = 0.0_ESMF_KIND_R8
 ! DATM uses atm fluxes in non-icy water
       if (atmocn_flux_from_atm .and. icewgt(i,j) <= 0.0_ESMF_KIND_R8) then
-        atmwgt1(i,j) = 0.0_ESMF_KIND_R8
+        atmwgt1(i,j) = 1.0_ESMF_KIND_R8
         icewgt1(i,j) = 0.0_ESMF_KIND_R8
-        wgtp01(i,j)  = 1.0_ESMF_KIND_R8
-        wgtm01(i,j)  = -1.0_ESMF_KIND_R8
+        wgtp01(i,j)  = 0.0_ESMF_KIND_R8
+        wgtm01(i,j)  = 0.0_ESMF_KIND_R8
       endif
 
       ! check wgts do add to 1 as expected


### PR DESCRIPTION
The changes are to use fluxes from bulk formula for open water without ice, this is to fix the issue of  sst increasing in datm-mom6-cice5.