### PR TITLE
update component_MOM6.mk to use MOM6-interface dir.

### DIFF
--- a/src/incmake/component_MOM6.mk
+++ b/src/incmake/component_MOM6.mk
@@ -3,8 +3,8 @@ mom6_mk = $(MOM6_BINDIR)/mom6.mk
 all_component_mk_files+=$(mom6_mk)
 
 # Location of source code and installation
-MOM6_SRCDIR?=$(ROOTDIR)/MOM6
-MOM6_BINDIR?=$(ROOTDIR)/MOM6/MOM6_INSTALL
+MOM6_SRCDIR?=$(ROOTDIR)/MOM6-interface
+MOM6_BINDIR?=$(ROOTDIR)/MOM6-interface/MOM6_INSTALL
 
 # Make sure the expected directories exist and are non-empty:
 $(call require_dir,$(MOM6_SRCDIR),MOM6 source directory)


### PR DESCRIPTION
This PR updates the MOM6 component directory to point to the MOM6-interface.
This is part of the series of PR that will enable cmake build for the UFS-s2s-model.

See associated PR #[137](https://github.com/ufs-community/ufs-s2s-model/pull/137) in UFS-s2s-model.