### PR TITLE
release/public-v2: update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "tests/produtil/NCEPLIBS-pyprodutil"]
 	path = tests/produtil/NCEPLIBS-pyprodutil
 	url = https://github.com/NOAA-EMC/NCEPLIBS-pyprodutil
-	branch = develop
+	branch = release/public-v2


### PR DESCRIPTION
Update submodule information for NCEPLIBS-pyprodutil in `.gitmodules`.

Associated PRs:

https://github.com/NOAA-EMC/NEMS/pull/80
https://github.com/NCAR/ccpp-framework/pull/324
https://github.com/NCAR/ccpp-physics/pull/500
https://github.com/NOAA-EMC/fv3atm/pull/173
https://github.com/ufs-community/ufs-weather-model/pull/205

For regression testing information, see https://github.com/ufs-community/ufs-weather-model/pull/205