### PR TITLE
set total forecast time to be real

### DIFF
--- a/src/MAIN_NEMS.F90
+++ b/src/MAIN_NEMS.F90
@@ -76,7 +76,6 @@
 !-----------------------------------------------------------------------
 !
       INTEGER :: MYPE                                                   &  !<-- The MPI task ID
-                ,NHOURS_FCST                                            &  !<-- Length of forecast in hours
                 ,NSECONDS_FCST                                          &  !<-- Length of forecast in seconds
                 ,TIMESTEP_SEC_WHOLE                                     &  !<-- Integer part of timestep
                 ,TIMESTEP_SEC_NUMERATOR                                 &  !<-- Numerator of fractional part
@@ -84,6 +83,7 @@
                 ,YY,MM,DD                                               &  !<-- Time variables for date
                 ,HH,MNS,SEC                                                !<-- Time variables for time of day
 !
+      REAL :: NHOURS_FCST                                                  !<-- Length of forecast in hours
 
       TYPE(NEMS_Rusage) :: rusage                                          !<-- Resource usage tracking object
 
@@ -395,7 +395,7 @@
       ESMF_ERR_ABORT(RC)
 ! ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
 !
-      NSECONDS_FCST=NHOURS_FCST*3600                                       !<-- The forecast length (sec) (REAL)
+      NSECONDS_FCST=nint(NHOURS_FCST*3600.)                             !<-- The forecast length (sec) (REAL)
 !
 !-----------------------------------------------------------------------
 !
@@ -540,6 +540,7 @@
 ! ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
 !
         NHOURS_FCST = HH_FINAL - HH_START
+        NSECONDS_FCST = nint(NHOURS_FCST*3600.)
 !
 ! ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
         MESSAGE_CHECK="MAIN: Re-set the clock after the ensemble run cycles."
@@ -547,7 +548,7 @@
 ! ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
 !
         CALL ESMF_TimeIntervalSet(timeInterval = RUNDURATION            &
-                                 ,h            = NHOURS_FCST            &
+                                 ,s            = NSECONDS_FCST          &
                                  ,rc           = RC)
         ESMF_ERR_ABORT(RC)
 !


### PR DESCRIPTION
Set total forecast time to be real number to allow flexible forecast time

Related PRs:

[fv3 PR #175](https://github.com/NOAA-EMC/fv3atm/pull/175)
[NEMS PR #81](https://github.com/NOAA-EMC/NEMS/pull/81)
[ufs-weather-model PR #206](https://github.com/ufs-community/ufs-weather-model/pull/206)