### PR TITLE
update required after UFS-weather PR #213

### DIFF
--- a/src/incmake/component_CCPP.mk
+++ b/src/incmake/component_CCPP.mk
@@ -44,7 +44,7 @@ $(ccpp_mk): configure
 	$(MODULE_LOGIC) ; \
 	set -xue                                                        ; \
 	export PATH_CCPP="$(CCPP_SRCDIR)"                               ; \
-	cd $(ROOTDIR)                                                   ; \
+	cd $(ROOTDIR)/FV3                                               ; \
 	$$PATH_CCPP/framework/scripts/ccpp_prebuild.py $(CCPP_CONFOPT)  ; \
 	cd $$PATH_CCPP                                                  ; \
 	./build_ccpp.sh ${BUILD_TARGET} "$$PATH_CCPP" $(ccpp_mk)          \


### PR DESCRIPTION
CCPP fails to build with gnu make in UFS-s2s-model following UFS-weather PR https://github.com/ufs-community/ufs-weather-model/pull/213
This fixes that issue.