### PR TITLE
Revert change in working directory for ccpp_prebuild.py call

### DIFF
--- a/src/incmake/component_CCPP.mk
+++ b/src/incmake/component_CCPP.mk
@@ -44,7 +44,7 @@ $(ccpp_mk): configure
 	$(MODULE_LOGIC) ; \
 	set -xue                                                        ; \
 	export PATH_CCPP="$(CCPP_SRCDIR)"                               ; \
-	cd $(ROOTDIR)/FV3                                               ; \
+	cd $(ROOTDIR)                                                   ; \
 	$$PATH_CCPP/framework/scripts/ccpp_prebuild.py $(CCPP_CONFOPT)  ; \
 	cd $$PATH_CCPP                                                  ; \
 	./build_ccpp.sh ${BUILD_TARGET} "$$PATH_CCPP" $(ccpp_mk)          \


### PR DESCRIPTION
This PR reverts a recent change to `src/incmake/component_CCPP.mk` so that `ccpp_prebuild.py` can be called again from the top-level directory rather than from `FV3`.

Associated PRs:

https://github.com/NCAR/ccpp-physics/pull/513
https://github.com/NOAA-EMC/fv3atm/pull/189
https://github.com/NOAA-EMC/NEMS/pull/84
https://github.com/ufs-community/ufs-weather-model/pull/238

For regression testing information, see https://github.com/ufs-community/ufs-weather-model/pull/238