### PR TITLE
Updates for JEDI linking/control

### DIFF
--- a/src/module_EARTH_GRID_COMP.F90
+++ b/src/module_EARTH_GRID_COMP.F90
@@ -248,6 +248,7 @@
         rc=RC)
       ESMF_ERR_RETURN(RC,RC_REG)
 
+#ifdef NEMS_DRIVER
       ! The NEMS Earth component is currently the top-level driver and
       ! does not need to coordinate Clocks with its parent.
       call ESMF_MethodRemove(EARTH_GRID_COMP, Driver_label_SetRunClock, rc=RC_REG)
@@ -255,7 +256,7 @@
       call NUOPC_CompSpecialize(EARTH_GRID_COMP, &
         specLabel=Driver_label_SetRunClock, specRoutine=NUOPC_NoOp, rc=RC_REG)
       ESMF_ERR_RETURN(RC,RC_REG)
-      
+#endif      
 #if 0
       call NUOPC_CompSpecialize(EARTH_GRID_COMP, &
         specLabel=Driver_label_Finalize, specRoutine=Finalize, &

--- a/src/module_EARTH_GRID_COMP.F90
+++ b/src/module_EARTH_GRID_COMP.F90
@@ -248,7 +248,7 @@
         rc=RC)
       ESMF_ERR_RETURN(RC,RC_REG)
 
-#ifdef NEMS_DRIVER
+#ifndef JEDI_DRIVER
       ! The NEMS Earth component is currently the top-level driver and
       ! does not need to coordinate Clocks with its parent.
       call ESMF_MethodRemove(EARTH_GRID_COMP, Driver_label_SetRunClock, rc=RC_REG)


### PR DESCRIPTION
This is part of the changes required to enable JEDI to link to and control the UFS for data assimilation. This change adds a compiler directive around a section of code in module_EARTH_GRID_COMP that assumes the NEMS earth component is the top level driver for the model. With the directive enabled, the clock can then be controlled from a higher level (JEDI) driver. 

Is part of NOAA-EMC/fv3atm/pull/201.