### PR TITLE
Make CCPP default to support removal of IPD

### DIFF
--- a/src/incmake/component_FV3.mk
+++ b/src/incmake/component_FV3.mk
@@ -10,16 +10,10 @@ FV3_BINDIR?=$(ROOTDIR)/FV3/FV3_INSTALL
 $(call require_dir,$(FV3_SRCDIR),FV3 source directory)
 
 # Make sure we're setting CCPP=Y if CCPP is enabled:
-ifneq (,$(findstring CCPP,$(COMPONENTS)))
-  ifeq (,$(findstring CCPP=Y,$(FV3_MAKEOPT)))
-    $(warning Adding CCPP=Y to FV3 make options because CCPP is listed as a component.)
-    override FV3_MAKEOPT += CCPP=Y
-  endif
   ifeq (,$(findstring PATH_CCPP=,$(FV3_MAKEOPT)))
-    $(warning Adding PATH_CCPP to FV3 make options because CCPP is listed as a component.)
+    $(warning Adding PATH_CCPP to FV3 make options.)
     override FV3_MAKEOPT += PATH_CCPP="$(CCPP_BINDIR)"
   endif
-endif
 
 FV3_FULL_OPTS=\
   COMP=FV3 \

--- a/src/incmake/dependencies.mk
+++ b/src/incmake/dependencies.mk
@@ -19,10 +19,7 @@ FMS:
 	$(call prepend_component,$@)
 
 FV3_DEPS=FMS
-
-ifneq (,$(findstring CCPP=Y,$(COMPONENTS)))
-  FV3_DEPS += CCPP
-endif
+FV3_DEPS += CCPP
 
 CCPP:
 	$(call prepend_component,$@)


### PR DESCRIPTION
This PR is part of the removal process of IPD from the UFS and addresses steps 3 and 5 in https://github.com/NOAA-EMC/fv3atm/issues/214.

Changes:
- Remove check for `CCPP=Y` in `src/incmake/component_FV3.mk` and `src/incmake/dependencies.mk`, since this is now the default.

Associated PRs:

https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere/pull/50
https://github.com/NCAR/ccpp-physics/pull/547
https://github.com/NOAA-EMC/fv3atm/pull/224
https://github.com/NOAA-EMC/NEMS/pull/87
https://github.com/ufs-community/ufs-weather-model/pull/357

For regression testing, see https://github.com/ufs-community/ufs-weather-model/pull/357.